### PR TITLE
Add support up to CUDA 11.2

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class CUDADevConfigConan(ConanFile):
     url = "https://github.com/ulricheck/conan-cuda_dev_config"
     author = "Ulrich Eck <ulrich.eck@tum.de>"
     options = { 
-        "cuda_version": ["10.1", "10.0", "9.0"],
+        "cuda_version": ["10.1", "10.0", "9.1", "9.0"],
         "cuda_root": "ANY",
         }
     default_options = (
@@ -38,7 +38,7 @@ class CUDADevConfigConan(ConanFile):
         )
     settings = "os", "arch"
     build_policy = "missing"
-    supportedVersions = ["10.0", "9.1", "9.0"]
+    supportedVersions = ["10.1", "10.0", "9.1", "9.0"]
 
     def package_id(self):
         self.info.header_only()

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,11 +88,15 @@ class CUDADevConfigConan(ConanFile):
     def get_cuda_path(self, dir_name):
         if tools.os_info.is_windows and not (os.path.exists(str(self.options.cuda_root)) and self.options.cuda_version=="10.0"):
             default_path = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v{}"
-            for version in self.supportedVersions:
-                cudaPath = default_path.format(version)
-                if os.path.exists(cudaPath):
-                    self.options.cuda_root = cudaPath
-                    break
+            preferred_path = default_path.format(self.options.cuda_version)
+            if(os.path.exists(preferred_path)):
+                self.options.cuda_root = preferred_path
+            else:
+                for version in self.supportedVersions:
+                    cudaPath = default_path.format(version)
+                    if os.path.exists(cudaPath):
+                        self.options.cuda_root = cudaPath
+                        break
         return os.path.join(str(self.options.cuda_root), dir_name)
 
     def run_nvcc_command(self, cmd):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env cuda
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile
+from conans import ConanFile, tools
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 import os
 import re
+
+## somehow exporting does not provide access to package options
+# so defining cuda_root only works with conan create, but not conan export ..
+if tools.os_info.is_windows:
+    CUDA_ROOT_DEFAULT = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.0"
+elif tools.os_info.is_linux:
+    CUDA_ROOT_DEFAULT = "/usr/local/cuda"
+else:
+    raise RuntimeError("Unsupported Platform")
 
 
 # pylint: disable=W0201
@@ -23,7 +32,10 @@ class CUDADevConfigConan(ConanFile):
         "cuda_version": ["10.0", "9.0"],
         "cuda_root": "ANY",
         }
-    default_options = "cuda_version=10.0", "cuda_root=/usr/local/cuda"
+    default_options = (
+        "cuda_version=10.0", 
+        "cuda_root=%s" % CUDA_ROOT_DEFAULT,
+        )
     settings = "os", "arch"
     build_policy = "missing"
 
@@ -36,7 +48,7 @@ class CUDADevConfigConan(ConanFile):
             self.cpp_info.bindirs = [self.cuda_bindir,]
             self.user_info.cuda_version = self.cuda_version
             self.user_info.cuda_root = str(self.options.cuda_root)
-            self.env_info.path.append(os.path.dirname(self.cuda_bindir))
+            self.env_info.path.append(str(self.options.cuda_root))
             self.env_info.CUDA_SDK_ROOT_DIR = str(self.options.cuda_root)
 
     @property

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class CUDADevConfigConan(ConanFile):
     url = "https://github.com/ulricheck/conan-cuda_dev_config"
     author = "Ulrich Eck <ulrich.eck@tum.de>"
     options = { 
-        "cuda_version": ["10.0", "9.0"],
+        "cuda_version": ["10.0", "9.1", "9.0"],
         "cuda_root": "ANY",
         }
     default_options = (
@@ -38,6 +38,7 @@ class CUDADevConfigConan(ConanFile):
         )
     settings = "os", "arch"
     build_policy = "missing"
+    supportedVersions = ["10.0", "9.1", "9.0"]
 
     def package_id(self):
         self.info.header_only()
@@ -61,6 +62,8 @@ class CUDADevConfigConan(ConanFile):
 
     @property
     def cuda_version(self):
+
+					
         if not hasattr(self, '_cuda_version'):
             cmd = "--version"
             result = self.run_nvcc_command(cmd)
@@ -80,6 +83,13 @@ class CUDADevConfigConan(ConanFile):
         return self.get_cuda_path("bin")
 
     def get_cuda_path(self, dir_name):
+        if tools.os_info.is_windows and not os.path.exists(self.options.cuda_root):
+            default_path = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v{}"
+            for version in self.supportedVersions:
+                cudaPath = default_path.format(version)
+                if os.path.exists(cudaPath):
+                    self.options.cuda_root = cudaPath
+                    break
         return os.path.join(str(self.options.cuda_root), dir_name)
 
     def run_nvcc_command(self, cmd):

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,11 +29,7 @@ class CUDADevConfigConan(ConanFile):
     url = "https://github.com/ulricheck/conan-cuda_dev_config"
     author = "Ulrich Eck <ulrich.eck@tum.de>"
     options = { 
-<<<<<<< HEAD
-        "cuda_version": ["10.0", "9.1", "9.0"],
-=======
         "cuda_version": ["10.1", "10.0", "9.0"],
->>>>>>> 146cfc838dad1692c6b9a05f41e4f93b3f951148
         "cuda_root": "ANY",
         }
     default_options = (

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,7 +64,7 @@ class CUDADevConfigConan(ConanFile):
         if not hasattr(self, '_cuda_version'):
             cmd = "--version"
             result = self.run_nvcc_command(cmd)
-            match = re.match(r".*, (\w+) (10.0).*", result.splitlines()[-1])
+            match = re.match( r".*, (\w+) ({}).*".format( self.options.cuda_version ), result.splitlines()[-1])
             self._cuda_version = None
             if match:
                 vt, version = match.groups()

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class CUDADevConfigConan(ConanFile):
     url = "https://github.com/ulricheck/conan-cuda_dev_config"
     author = "Ulrich Eck <ulrich.eck@tum.de>"
     options = { 
-        "cuda_version": ["10.0", "9.0"],
+        "cuda_version": ["10.1", "10.0", "9.0"],
         "cuda_root": "ANY",
         }
     default_options = (

--- a/conanfile.py
+++ b/conanfile.py
@@ -83,7 +83,7 @@ class CUDADevConfigConan(ConanFile):
         return self.get_cuda_path("bin")
 
     def get_cuda_path(self, dir_name):
-        if tools.os_info.is_windows and not os.path.exists(self.options.cuda_root):
+        if tools.os_info.is_windows and not os.path.exists(str(self.options.cuda_root)):
             default_path = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v{}"
             for version in self.supportedVersions:
                 cudaPath = default_path.format(version)

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,9 +35,9 @@ class CUDADevConfigConan(ConanFile):
         if self.have_cuda_dev:
             self.cpp_info.bindirs = [self.cuda_bindir,]
             self.user_info.cuda_version = self.cuda_version
-            self.user_info.cuda_root = self.options.cuda_root
+            self.user_info.cuda_root = str(self.options.cuda_root)
             self.env_info.path.append(os.path.dirname(self.cuda_bindir))
-            self.env_info.CUDA_SDK_ROOT_DIR = self.options.cuda_root
+            self.env_info.CUDA_SDK_ROOT_DIR = str(self.options.cuda_root)
 
     @property
     def have_cuda_dev(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class CUDADevConfigConan(ConanFile):
     url = "https://github.com/ulricheck/conan-cuda_dev_config"
     author = "Ulrich Eck <ulrich.eck@tum.de>"
     options = { 
-        "cuda_version": ["10.1", "10.0", "9.1", "9.0"],
+        "cuda_version": ["10.2", "10.1", "10.0", "9.1", "9.0"],
         "cuda_root": "ANY",
         }
     default_options = (
@@ -38,7 +38,7 @@ class CUDADevConfigConan(ConanFile):
         )
     settings = "os", "arch"
     build_policy = "missing"
-    supportedVersions = ["10.1", "10.0", "9.1", "9.0"]
+    supportedVersions = ["10.2", "10.1", "10.0", "9.1", "9.0"]
 
     def package_id(self):
         self.info.header_only()


### PR DESCRIPTION
- Include new options for cuda_version
- Don't use the default cuda 10.0 on windows, when it is installed, but not chosen via the `cuda_version` option
- `nvcc -v` now reports the build-id in the last line: fix the regex-parser that detects the version